### PR TITLE
virtual env create section change python3 to python

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is a [FastAPI](https://fastapi.tiangolo.com/) application built for high-pe
 2. Create and activate a virtual environment:
 
     ```bash
-    python3 -m venv venv
+    python -m venv venv
     source venv/bin/activate  # On Windows: venv\Scripts\activate
     ```
 


### PR DESCRIPTION
In Create virtual environment section 
when i try to  run 
"python3 -m venv venv"

in bash this error show
"bash: python3: command not found"

in cmd this error show
"'python3' is not recognized as an internal or external command, operable program or batch file."

